### PR TITLE
Logs should be disabled so they don't corrupt the json output

### DIFF
--- a/lib/ktlint/plugin.rb
+++ b/lib/ktlint/plugin.rb
@@ -168,7 +168,7 @@ module Danger
 
         return if targets.empty?
 
-        [JSON.parse(`ktlint #{targets.join(' ')} --reporter=json --relative`)]
+        [JSON.parse(`ktlint #{targets.join(' ')} --reporter=json --relative --log-level=none`)]
       end
     end
 


### PR DESCRIPTION
Disable logs using `--log-level=none`

See #13 for details